### PR TITLE
Attempt to send amount when no contract is found

### DIFF
--- a/contracts/token/oft/v2/OFTCoreV2.sol
+++ b/contracts/token/oft/v2/OFTCoreV2.sol
@@ -142,11 +142,6 @@ abstract contract OFTCoreV2 is NonblockingLzApp {
             creditedPackets[_srcChainId][_srcAddress][_nonce] = true;
         }
 
-        if (!_isContract(to)) {
-            emit NonContractAddress(to);
-            return;
-        }
-
         // workaround for stack too deep
         uint16 srcChainId = _srcChainId;
         bytes memory srcAddress = _srcAddress;

--- a/contracts/token/oft/v2/OFTCoreV2.sol
+++ b/contracts/token/oft/v2/OFTCoreV2.sol
@@ -57,6 +57,10 @@ abstract contract OFTCoreV2 is NonblockingLzApp {
         emit ReceiveFromChain(_srcChainId, _to, _amount);
 
         // call
+        if (!_isContract(_to)) {
+            emit NonContractAddress(_to);
+            return;
+        }
         IOFTReceiverV2(_to).onOFTReceived{gas: _gasForCall}(_srcChainId, _srcAddress, _nonce, _from, _amount, _payload);
     }
 


### PR DESCRIPTION
This design choice would be: Instead of locking the tokens on the contract we would send them to the requested address (users would be able to recover in case they sent to an EOA or to a contract that is not yet deployed at that address).
Closes #10 